### PR TITLE
When the HTS221 device isn't available don't crash the server

### DIFF
--- a/lib/hts221.ex
+++ b/lib/hts221.ex
@@ -224,7 +224,7 @@ defmodule HTS221 do
   values into percent.
   """
   @spec calculate_humidity(Humidity.t(), Calibration.t()) :: float()
-  def calculate_humidity(humidity, calibration) do
+  def calculate_humidity(humidity, %Calibration{} = calibration) do
     h0 = Calibration.h0(calibration)
     h1 = Calibration.h1(calibration)
     h = humidity.raw

--- a/lib/hts221/server.ex
+++ b/lib/hts221/server.ex
@@ -29,9 +29,16 @@ defmodule HTS221.Server do
 
   If you a custom transport implementation then the `:transport` argument to
   this server will look different.
+
+  If the HTS221 is not detected this server will log that it was not found and
+  return `:ignore` on the `GenServer.init/1` callback. This is useful if your FW
+  will run on devices with different hardware attached and don't want the device
+  availability to crash your application supervisor.
   """
 
   use GenServer
+
+  require Logger
 
   alias HTS221.{CTRLReg1, CTRLReg2, Transport}
 
@@ -111,6 +118,10 @@ defmodule HTS221.Server do
          :ok = setup_ctrl_reg1(transport) do
       {:ok, %State{calibration: calibration, transport: transport}}
     else
+      {:error, :device_not_available} ->
+        Logger.info("HTS221 not detected on device")
+        :ignore
+
       error ->
         {:stop, error}
     end


### PR DESCRIPTION
In some cases where the HTS221 sensor is optional, we don't want to crash
a firmware's application starts due to it missing.

This update will by default gracefully stop the `HTS221.Server` so that
firmwares that use this library will continue to work if the sensor is
not on the device. This does log that we tried to use the sensor but we
were unable to find it.